### PR TITLE
Changed array to normal functions for Nashorn compatibility

### DIFF
--- a/js/pjxml.js
+++ b/js/pjxml.js
@@ -332,7 +332,7 @@ var pjXML = (function () {
   Node.prototype.select = function (xpath) {
     if (!Array.isArray(xpath)) {
       xpath = xpath.replace('//', '/>').split('/');
-      xpath = xpath.reduce((a, v) => {
+      xpath = xpath.reduce(function (a, v) {
         if (v) {
           a.push(v);
         }
@@ -358,7 +358,7 @@ var pjXML = (function () {
     var ea = this.elements(name);
 
     if (xpath.length > 1) {
-      ea.map((el) => {
+      ea.map(function (el) {
         ra = ra.concat(el.select(xpath.slice(1)));
       });
     } else {
@@ -366,7 +366,7 @@ var pjXML = (function () {
     }
 
     if (recurse) {
-      this.elements().map((el) => {
+      this.elements().map(function (el) {
         ra = ra.concat(el.select(xpath));
       });
     }
@@ -402,7 +402,7 @@ var pjXML = (function () {
   }
 
   Node.prototype.elements = function (name) {
-    return this.content.reduce((ea, o) => {
+    return this.content.reduce(function (ea, o) {
       if (o instanceof Node && o.type == node_types.ELEMENT_NODE && (!name || name == '*' || o.name == name)) {
         ea.push(o);
       }


### PR DESCRIPTION
In order to be fully ES5 compliant the replacement of all arrow functions is needed. This is useful to make the library work also in the Java Nashorn JS Engine that only support JS ES5. 
A simple replacement with normal function allows to use this library also in Nashorn and any other ES5 compliant JS engines.

Thanks,
Damiano