### PR TITLE
Fixed early decoding of &-encoded characters

### DIFF
--- a/js/pjxml.js
+++ b/js/pjxml.js
@@ -83,7 +83,7 @@ var pjXML = (function () {
     }
 
     var ch = this.read();
-    if (ch == '&' || (this.inDTD && ch == '%')) {
+    if (this.inDTD && ch == '%') {
       var er = '';
       while ((ch = this.read()) != ';' && ch) {
         er += ch;
@@ -268,7 +268,7 @@ var pjXML = (function () {
 
     while (ch = lex.nextChar()) {
       if (ch == '<') {
-        this.append(s);
+        this.append(lex.replaceEntities(s));
         s = '';
         ch = lex.nextChar();
         switch (ch) {
@@ -325,7 +325,7 @@ var pjXML = (function () {
     }
 
     if (s.length) {
-      this.append(s);
+      this.append(lex.replaceEntities(s));
     }
   };
 


### PR DESCRIPTION
It seems that &-encoded characters are being decoded too early in the parsing process, which I noticed could lead to problems like this (note that it's erroneously creating a node with the name "</test"):

*PARSING THIS:*
```javascript
let text = '<test>Hello&lt;</test>';
pjXML.parse(text);
```

*RESULTS IN THIS:*
```json
{
  "type": 9,
  "content": [
    "",
    {
      "type": 1,
      "content": [
        "Hello",
        {
          "type": 1,
          "content": [],
          "name": "</test",
          "attributes": {}
        }
      ],
      "name": "test",
      "attributes": {}
    }
  ]
}
```

I tracked this down to Lexer.prototype.nextChar, which was decoding &-encoded characters during lexing, which I think is too early. I made what appears to me to be a successful fix (though I haven't deeply studied the code, so it's possible there's some case where you'd want the decoding done earlier). In any event, here's the result of running the same test code with my fix in place:

```json
{
  "type": 9,
  "content": [
    "",
    {
      "type": 1,
      "content": [
        "Hello<"
      ],
      "name": "test",
      "attributes": {}
    }
  ]
}
```

I hope this helps!