### PR TITLE
Allow non-recursive select() with lambdas

### DIFF
--- a/js/pjxml.js
+++ b/js/pjxml.js
@@ -406,6 +406,8 @@ var pjXML = (function () {
           depth = 2;
         } else if (res) {
           ar.push(nd);
+        } else if (res === null) {
+          depth = 1;
         }
 
         if (--depth) {

--- a/js/pjxml.js
+++ b/js/pjxml.js
@@ -398,19 +398,26 @@ var pjXML = (function () {
     if (typeof xpath === 'function') {
       const ar = [];
 
-      function safWorker(nd) {
-        if (xpath(nd)) {
+      function safWorker(nd, xpath, depth) {
+        const res = xpath(nd);
+
+        if (typeof res === 'function') {
+          xpath = res;
+          depth = 2;
+        } else if (res) {
           ar.push(nd);
         }
 
-        const el = nd.elements();
+        if (--depth) {
+          const el = nd.elements();
 
-        for (let i = 0; i < el.length; i++) {
-          safWorker(el[i]);
+          for (let i = 0; i < el.length; i++) {
+            safWorker(el[i], xpath, depth);
+          }
         }
       }
 
-      safWorker(this);
+      safWorker(this, xpath, 0);
 
       return ar;
     }

--- a/nested-lambda-demo.html
+++ b/nested-lambda-demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+
+<script src='js/pjxml.js'></script>
+
+<script>
+function parsexml(text)
+{
+    const doc = pjXML.parse(text);
+    const paragraphs = document.getElementsByTagName("p");
+    for (var i = 0; i < paragraphs.length; ++i)
+    {
+        const val = paragraphs[i].id;
+        const key = isNaN(val) ? "name" : "number";
+        paragraphs[i].innerText = doc.selectAll(
+            r => !(r.name == "score-partwise") ? false :
+            r => !(r.name == "part") ? false :
+            r => !(r.name == "measure") ? false :
+            r => !(r.name == "note") ? false :
+            r => !(r.name == "lyric" && r.attributes[key] == val) ? false :
+            r => r.name == "text").map(node => node.text()).join(" | ");
+    }
+    content.innerText = text;
+}
+
+function filechange()
+{
+    const reader = new FileReader();
+    reader.addEventListener("load", () => parsexml(reader.result));
+    reader.readAsText(xml.files.item(0));
+}
+</script>
+
+<h3>Demo on parsing MusicXML with pjXML using nested lambdas</h3>
+<h4>Usage: Download <a href='https://lilypond.org/doc/v2.25/input/regression/musicxml/71/lily-1941d34e.xml'>lily-1941d34e.xml</a> and drop it into the below file input field.</h4>
+<input type='file' id='xml' onchange='filechange()'>
+<hr><p id='1'></p>
+<hr><p id='2'></p>
+<hr><p id='Verse'></p>
+<hr><p id='Chorus'></p>
+<hr><pre id='content'></pre>


### PR DESCRIPTION
The feature works by accepting additional arrows to indicate the relative depth from the current node's perspective at which to search, like in r => r => r.name == "ChildTag".

It can help avoid ambiguous results and speed up searches tremendously.

Mixing in ternary operators allows to decide for every visited node whether or not to recurse into its children.
An example for this approach is given in nested-lambda-demo.html.